### PR TITLE
"Fixed" position size splitting

### DIFF
--- a/MQL4/Scripts/PSC-Trader.mq4
+++ b/MQL4/Scripts/PSC-Trader.mq4
@@ -397,11 +397,12 @@ void OnStart()
    // Going through a cycle to execute multiple TP trades.
    // ak
    double AccumulatedPositionSize = 0;
+   double ArrayPositionSize[];
    
-   for (int j = n-1; j >= 0; j--)
+   ArrayResize(ArrayPositionSize, n + 1);
+   
+   for (int j = n; j >= 0; j--)
    {
-      double order_sl = sl;
-      double order_tp = NormalizeDouble(ScriptTPValue[j], _Digits);
       double position_size = PositionSize * ScriptTPShareValue[j] / 100.0;
    
       if (position_size < MinLot) 
@@ -432,6 +433,18 @@ void OnStart()
       {
          position_size = PositionSize - AccumulatedPositionSize;
       }
+      
+      Print(PositionSize, "-----------", position_size);
+      
+      ArrayPositionSize[j] = position_size;
+   }
+   
+   for (int j = 0; j < n; j++)
+   {
+      double order_sl = sl;
+      double order_tp = NormalizeDouble(ScriptTPValue[j], _Digits);
+      double position_size = ArrayPositionSize[j];
+      
       
    	// Market execution mode - preparation.
    	if ((Execution_Mode == SYMBOL_TRADE_EXECUTION_MARKET) && (entry_type == Instant))

--- a/MQL4/Scripts/PSC-Trader.mq4
+++ b/MQL4/Scripts/PSC-Trader.mq4
@@ -395,6 +395,9 @@ void OnStart()
    }
 
    // Going through a cycle to execute multiple TP trades.
+   // ak
+   double AccumulatedPositionSize = 0;
+   
    for (int j = 0; j < n; j++)
    {
       double order_sl = sl;
@@ -420,6 +423,16 @@ void OnStart()
          Print("Adjusting position size to the broker's Lot Step parameter.");
       }
 
+      // ak
+      if ( j < n-1) 
+      {
+         AccumulatedPositionSize += position_size;
+      } 
+      else 
+      {
+         position_size = PositionSize - AccumulatedPositionSize;
+      }
+      
    	// Market execution mode - preparation.
    	if ((Execution_Mode == SYMBOL_TRADE_EXECUTION_MARKET) && (entry_type == Instant))
    	{

--- a/MQL4/Scripts/PSC-Trader.mq4
+++ b/MQL4/Scripts/PSC-Trader.mq4
@@ -398,7 +398,7 @@ void OnStart()
    // ak
    double AccumulatedPositionSize = 0;
    
-   for (int j = 0; j < n; j++)
+   for (int j = n-1; j >= 0; j--)
    {
       double order_sl = sl;
       double order_tp = NormalizeDouble(ScriptTPValue[j], _Digits);
@@ -424,7 +424,7 @@ void OnStart()
       }
 
       // ak
-      if ( j < n-1) 
+      if ( j > 0) 
       {
          AccumulatedPositionSize += position_size;
       } 


### PR DESCRIPTION
Changed the multiple TP function to have the last portion of the trade accommodate for the "deltas" of the others

e.g.
initial position size is 0.11 and 4 TPs are set 25% each
with the "original" script, this would be 4 trades each of 0.02 for a total of 0.08 lots and not 0.11

this change will make the last order 0.05 instead of 0.02 thus the total still 0.11 lots